### PR TITLE
Docker compose files for running the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 .idea/
+.DS_STORE
+docs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY poetry.lock pyproject.toml README.md ./
 # Use no-root because the root code folder hasn't been added yet
 RUN poetry install --no-root --without dev
 COPY kwg_api/ kwg_api/
-CMD ["poetry", "run", "uvicorn", "kwg_api.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["poetry", "run", "uvicorn", "kwg_api.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.10
 
-ENV base_address_http=http://stko-kwg.geog.ucsb.edu
-ENV base_address_https=https://stko-kwg.geog.ucsb.edu
 WORKDIR ./kwg-api/
 
 RUN pip install poetry

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ poetry run black .
 poetry run isort .
 ```
 
-Install [sphinx-doc](https://www.sphinx-doc.org/en/master/usage/installation.html)
-
 ### Running Locally
 
 The API can be run locally when developing. To run,
@@ -38,6 +36,14 @@ The API can be run locally when developing. To run,
 ```bash
 poetry install
 poetry run uvicorn kwg_api.main:app --reload --port 80
+```
+
+#### Via Docker
+
+The API can also be run using the `docker-compose.dev.yaml` file with
+
+```commandline
+docker-compose -f docker-compose.local.yaml up
 ```
 
 ### Testing

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  api:
+    build: '.'
+    ports:
+      - '80:80'
+    environment:
+      - base_address_http=http://staging.knowwheregraph.org
+      - base_address_https=https://staging.knowwheregraph.org

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - '80:80'
     environment:
-      - base_address_http=http://stko-kwg.geog.ucsb.edu
-      - base_address_https=https://stko-kwg.geog.ucsb.edu
+      - base_address_http=http://staging.knowwheregraph.org
+      - base_address_https=https://staging.knowwheregraph.org
     networks:
       - kwg_network

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   api:
+    container_name: kg-api
     build:
       context: ./kwg-api/
       dockerfile: Dockerfile

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   api:
-    container_name: kg-api
+    container_name: kwg-api
     build:
       context: ./kwg-api/
       dockerfile: Dockerfile

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -2,9 +2,11 @@ version: '3'
 
 services:
   api:
-    build: '.'
+    build:
+      context: ./kwg-api/
+      dockerfile: Dockerfile
     ports:
-      - '80:80'
+      - '8080:8080'
     environment:
       - base_address_http=http://staging.knowwheregraph.org
       - base_address_https=https://staging.knowwheregraph.org

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   api:
+    container_name: kg-api
     build:
       context: ./kwg-api/
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   api:
-    container_name: kg-api
+    container_name: kwg-api
     build:
       context: ./kwg-api/
       dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,9 +2,11 @@ version: '3'
 
 services:
   api:
-    build: '.'
+    build:
+      context: ./kwg-api/
+      dockerfile: Dockerfile
     ports:
-      - '80:80'
+      - '8080:8080'
     environment:
       - base_address_http=http://stko-kwg.geog.ucsb.edu
       - base_address_https=https://stko-kwg.geog.ucsb.edu


### PR DESCRIPTION
Fixes #3 
Small PR that allows the API to be configured via docker-compose. This will play a role in the deployment of KWG services.