### PR TITLE
Redirect browse fix

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -12,5 +12,6 @@ services:
     environment:
       - base_address_http=http://localhost
       - base_address_https=https://localhost
+      - base_browse_address=staging.knowwheregraph.org/browse
     networks:
       - kwg_network

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -12,6 +12,6 @@ services:
     environment:
       - base_address_http=http://localhost
       - base_address_https=https://localhost
-      - base_browse_address=staging.knowwheregraph.org/browse
+      - base_browse_address=https://staging.knowwheregraph.org/browse
     networks:
       - kwg_network

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -10,8 +10,8 @@ services:
     ports:
       - '8080:8080'
     environment:
-      - base_address_http=http://stko-kwg.geog.ucsb.edu
-      - base_address_https=https://stko-kwg.geog.ucsb.edu
+      - base_address_http=http://kwg-api:8080
+      - base_address_https=https://kwg-api:8080
       - base_browse_address=https://stko-kwg.geog.ucsb.edu/browse
     networks:
       - kwg_network

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -12,5 +12,6 @@ services:
     environment:
       - base_address_http=http://stko-kwg.geog.ucsb.edu
       - base_address_https=https://stko-kwg.geog.ucsb.edu
+      - base_browse_address=https://stko-kwg.geog.ucsb.edu/browse
     networks:
       - kwg_network

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -12,5 +12,6 @@ services:
     environment:
       - base_address_http=http://staging.knowwheregraph.org
       - base_address_https=https://staging.knowwheregraph.org
+      - base_browse_address=staging.knowwheregraph.org/browse
     networks:
       - kwg_network

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -10,8 +10,8 @@ services:
     ports:
       - '8080:8080'
     environment:
-      - base_address_http=http://staging.knowwheregraph.org
-      - base_address_https=https://staging.knowwheregraph.org
+      - base_address_http=http://kwg-api:8080
+      - base_address_https=https://kwg-api:8080
       - base_browse_address=https://staging.knowwheregraph.org/browse
     networks:
       - kwg_network

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -12,6 +12,6 @@ services:
     environment:
       - base_address_http=http://staging.knowwheregraph.org
       - base_address_https=https://staging.knowwheregraph.org
-      - base_browse_address=staging.knowwheregraph.org/browse
+      - base_browse_address=https://staging.knowwheregraph.org/browse
     networks:
       - kwg_network

--- a/kwg_api/api/node_negotiator.py
+++ b/kwg_api/api/node_negotiator.py
@@ -75,11 +75,9 @@ class NodeNegotiator(ContentNegotiator):
 
         :return: A response signaling a redirect to a URL
         """
-        browse_url = f"{self.base_browse_address}/browse/"
         resource_id_shortened = PrefixBuilder.resolve_prefix(
             self.request_url, self.resource_id
         )
         if not resource_id_shortened:
             resource_id_shortened = self.resource_id
-        print(self.base_address_https)
-        return RedirectResponse(url=f"{browse_url}#{resource_id_shortened}")
+        return RedirectResponse(url=f"{self.base_browse_address}#{resource_id_shortened}")

--- a/kwg_api/api/node_negotiator.py
+++ b/kwg_api/api/node_negotiator.py
@@ -75,7 +75,7 @@ class NodeNegotiator(ContentNegotiator):
 
         :return: A response signaling a redirect to a URL
         """
-        browse_url = f"{self.base_address_https}/browse/"
+        browse_url = f"{self.base_browse_address_https}/browse/"
         resource_id_shortened = PrefixBuilder.resolve_prefix(
             self.request_url, self.resource_id
         )

--- a/kwg_api/api/node_negotiator.py
+++ b/kwg_api/api/node_negotiator.py
@@ -75,7 +75,7 @@ class NodeNegotiator(ContentNegotiator):
 
         :return: A response signaling a redirect to a URL
         """
-        browse_url = f"{self.base_browse_address_https}/browse/"
+        browse_url = f"{self.base_browse_address}/browse/"
         resource_id_shortened = PrefixBuilder.resolve_prefix(
             self.request_url, self.resource_id
         )

--- a/kwg_api/lib/content_negotiator.py
+++ b/kwg_api/lib/content_negotiator.py
@@ -18,6 +18,7 @@ class ContentNegotiator:
         """
         self.base_address_http = os.getenv("base_address_http")
         self.base_address_https = os.getenv("base_address_https")
+        self.base_browse_address = os.getenv("base_browse_address")
         accept_header = request.headers.get("accept")
         if not accept_header:
             raise ValueError("Failed to read the request headers")

--- a/kwg_api/lib/prefix_builder.py
+++ b/kwg_api/lib/prefix_builder.py
@@ -33,6 +33,7 @@ class PrefixBuilder:
             base_kwg_url_http=os.environ.get("base_address_http"),
             base_kwg_url_https=os.environ.get("base_address_https"),
         )
+        print( json.loads(context))
         return json.loads(context)
 
     @staticmethod
@@ -54,7 +55,7 @@ class PrefixBuilder:
             # Split the resource out of the . It should look like
             # {base_address}/lod/resource/
             base_url = str(full_uri).split(resource_id)[0]
-
+            print(base_url)
         except IndexError:
             logging.warning(
                 f"Failed to find a prefix for URI {full_uri}", exc_info=True
@@ -62,6 +63,8 @@ class PrefixBuilder:
             return None
         try:
             # Find the prefix (key) whose full path (value) matches
+            print("1234")
+            print(f"{vocab[base_url]}:{resource_id}")
             return f"{vocab[base_url]}:{resource_id}"
         except KeyError:
             logging.warning(

--- a/kwg_api/lib/prefix_builder.py
+++ b/kwg_api/lib/prefix_builder.py
@@ -33,7 +33,6 @@ class PrefixBuilder:
             base_kwg_url_http=os.environ.get("base_address_http"),
             base_kwg_url_https=os.environ.get("base_address_https"),
         )
-        print( json.loads(context))
         return json.loads(context)
 
     @staticmethod
@@ -55,7 +54,6 @@ class PrefixBuilder:
             # Split the resource out of the . It should look like
             # {base_address}/lod/resource/
             base_url = str(full_uri).split(resource_id)[0]
-            print(base_url)
         except IndexError:
             logging.warning(
                 f"Failed to find a prefix for URI {full_uri}", exc_info=True
@@ -63,8 +61,6 @@ class PrefixBuilder:
             return None
         try:
             # Find the prefix (key) whose full path (value) matches
-            print("1234")
-            print(f"{vocab[base_url]}:{resource_id}")
             return f"{vocab[base_url]}:{resource_id}"
         except KeyError:
             logging.warning(


### PR DESCRIPTION
1. NGINX rewrites the base address to the docker name. Change the base_url to reflect this
2. We still need to redirect to a full hostname. So add a new env var
